### PR TITLE
Set default database to sqlite

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,8 @@ APP_URL=http://localhost
 DB_CONNECTION=sqlite
 DB_HOST=127.0.0.1
 DB_PORT=3306
-DB_DATABASE=database/database.sqlite
+dd(env('DB_DATABASE'))
+dd(database_path('database.sqlite')
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 

--- a/.env
+++ b/.env
@@ -5,10 +5,10 @@ APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 
-DB_CONNECTION=mysql
+DB_CONNECTION=sqlite
 DB_HOST=127.0.0.1
 DB_PORT=3306
-DB_DATABASE=laravel_sample_intermediate_task_list
+DB_DATABASE=database/database.sqlite
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 

--- a/config/database.php
+++ b/config/database.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'mysql'),
+    'default' => env('DB_CONNECTION', 'sqlite'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
To run application out-of-the box for users who don't have MySQL server installed and configured - it's better to use SQLite. 

Otherwise `php artisan migrate` will result in
```
  [Illuminate\Database\QueryException]
  SQLSTATE[HY000] [2002] Connection refused (SQL: select * from information_schema.tables where table_schema = laravel_sample_intermediate_task_list and table_name = migration
  s)



  [PDOException]
  SQLSTATE[HY000] [2002] Connection refused
```